### PR TITLE
Fix overlapping labels in the item card

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -567,13 +567,15 @@ body {
   justify-content: space-between;
   align-items: flex-start;
   padding: 1.25rem 1.25rem 0;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .item-title-section {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  flex: 1;
+  flex: 1 1 auto;
   min-width: 0;
 }
 
@@ -600,6 +602,14 @@ body {
   font-size: 0.75rem;
   font-weight: 500;
   flex-shrink: 0;
+}
+
+.item-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0 1.25rem;
+  margin-top: 0.5rem;
 }
 
 .status-dropdown-container {
@@ -666,7 +676,7 @@ body {
 
 .item-body {
   padding: 1.25rem;
-  padding-top: 1rem;
+  padding-top: 0.75rem;
 }
 
 .quantity-section {

--- a/src/App.css
+++ b/src/App.css
@@ -608,22 +608,31 @@ body {
 
 .status-dropdown {
   padding: 0.5rem 0.75rem;
-  border: 2px solid;
-  border-radius: 8px;
+  border: none;
+  border-radius: 20px;
   cursor: pointer;
   font-size: 0.875rem;
   font-weight: 600;
   transition: all 0.2s;
   appearance: none;
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%23ffffff' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%23ffffff' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
   background-position: right 0.5rem center;
   background-repeat: no-repeat;
   background-size: 1rem;
   padding-right: 2.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  min-width: 80px;
 }
 
 .status-dropdown:hover {
   opacity: 0.9;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.status-dropdown:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.3);
 }
 
 .item-actions {
@@ -1038,6 +1047,7 @@ body {
     padding-right: 1.75rem;
     font-size: 0.7rem;
     min-width: auto;
+    border-radius: 14px;
   }
   
   .status-buttons {

--- a/src/App.css
+++ b/src/App.css
@@ -679,6 +679,23 @@ body {
   padding-top: 0.75rem;
 }
 
+.meta-qty-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0 0 0.5rem 0;
+}
+
+.meta-qty-row .item-meta {
+  padding: 0; /* override default padding so row aligns nicely */
+  margin-top: 0;
+}
+
+.meta-qty-row .quantity-display {
+  margin: 0; /* remove bottom margin when inline */
+}
+
 .quantity-section {
   margin-bottom: 1.5rem;
 }

--- a/src/components/AddItemForm.jsx
+++ b/src/components/AddItemForm.jsx
@@ -4,6 +4,7 @@ const AddItemForm = ({ onSubmit, onCancel, categories, statuses }) => {
   const [formData, setFormData] = useState({
     name: '',
     quantity: '',
+    maxQuantity: 50,
     unit: 'items',
     category: 'Pantry',
     status: 'Enough',
@@ -15,11 +16,13 @@ const AddItemForm = ({ onSubmit, onCancel, categories, statuses }) => {
     if (formData.name.trim() && formData.quantity !== '') {
       onSubmit({
         ...formData,
-        quantity: parseFloat(formData.quantity) || 0
+        quantity: parseFloat(formData.quantity) || 0,
+        maxQuantity: parseFloat(formData.maxQuantity) || 50
       });
       setFormData({
         name: '',
         quantity: '',
+        maxQuantity: 50,
         unit: 'items',
         category: 'Pantry',
         status: 'Enough',
@@ -75,6 +78,21 @@ const AddItemForm = ({ onSubmit, onCancel, categories, statuses }) => {
               />
             </div>
             <div className="form-group">
+              <label htmlFor="maxQuantity">Max Quantity</label>
+              <input
+                id="maxQuantity"
+                type="number"
+                value={formData.maxQuantity}
+                onChange={(e) => handleChange('maxQuantity', e.target.value)}
+                placeholder="50"
+                min="1"
+                step="1"
+              />
+            </div>
+          </div>
+
+          <div className="form-row">
+            <div className="form-group">
               <label htmlFor="unit">Unit</label>
               <select
                 id="unit"
@@ -86,9 +104,6 @@ const AddItemForm = ({ onSubmit, onCancel, categories, statuses }) => {
                 ))}
               </select>
             </div>
-          </div>
-
-          <div className="form-row">
             <div className="form-group">
               <label htmlFor="category">Category</label>
               <select

--- a/src/components/InventoryItem.jsx
+++ b/src/components/InventoryItem.jsx
@@ -191,15 +191,17 @@ const InventoryItem = ({ item, onUpdate, onDelete, categories, statuses }) => {
       </div>
 
       <div className="item-body">
-        <div className="item-meta">
-          <span className="category-badge">{item.category}</span>
-        </div>
-        <div className="quantity-section">
+        <div className="meta-qty-row">
+          <div className="item-meta">
+            <span className="category-badge">{item.category}</span>
+          </div>
           <div className="quantity-display">
             <span className="quantity-number">{item.quantity}</span>
             <span className="quantity-unit">{item.unit}</span>
           </div>
-          
+        </div>
+
+        <div className="quantity-section">
           <div className="quantity-slider-container">
             <div className="slider-labels">
               <span>0</span>

--- a/src/components/InventoryItem.jsx
+++ b/src/components/InventoryItem.jsx
@@ -98,6 +98,19 @@ const InventoryItem = ({ item, onUpdate, onDelete, categories, statuses }) => {
                 />
               </div>
               <div className="edit-group">
+                <label>Max Quantity</label>
+                <input
+                  type="number"
+                  value={editData.maxQuantity || 50}
+                  onChange={(e) => setEditData({ ...editData, maxQuantity: parseFloat(e.target.value) || 50 })}
+                  min="1"
+                  step="1"
+                />
+              </div>
+            </div>
+
+            <div className="edit-row">
+              <div className="edit-group">
                 <label>Unit</label>
                 <select
                   value={editData.unit}
@@ -108,9 +121,6 @@ const InventoryItem = ({ item, onUpdate, onDelete, categories, statuses }) => {
                   ))}
                 </select>
               </div>
-            </div>
-
-            <div className="edit-row">
               <div className="edit-group">
                 <label>Category</label>
                 <select
@@ -122,6 +132,9 @@ const InventoryItem = ({ item, onUpdate, onDelete, categories, statuses }) => {
                   ))}
                 </select>
               </div>
+            </div>
+
+            <div className="edit-row">
               <div className="edit-group">
                 <label>Status</label>
                 <select
@@ -188,12 +201,12 @@ const InventoryItem = ({ item, onUpdate, onDelete, categories, statuses }) => {
           <div className="quantity-slider-container">
             <div className="slider-labels">
               <span>0</span>
-              <span>{Math.max(36, item.quantity * 2)}</span>
+              <span>{item.maxQuantity || 50}</span>
             </div>
             <input
               type="range"
               min="0"
-              max={Math.max(36, item.quantity * 2)}
+              max={item.maxQuantity || 50}
               value={item.quantity}
               onChange={(e) => handleQuickQuantityUpdate(parseFloat(e.target.value))}
               className="quantity-slider"

--- a/src/components/InventoryItem.jsx
+++ b/src/components/InventoryItem.jsx
@@ -171,7 +171,6 @@ const InventoryItem = ({ item, onUpdate, onDelete, categories, statuses }) => {
         <div className="item-title-section">
           <span className="category-emoji">{getCategoryEmoji(item.category)}</span>
           <h2 className="item-name">{item.name}</h2>
-          <span className="category-badge">{item.category}</span>
         </div>
         <div className="status-dropdown-container">
           <select
@@ -192,6 +191,9 @@ const InventoryItem = ({ item, onUpdate, onDelete, categories, statuses }) => {
       </div>
 
       <div className="item-body">
+        <div className="item-meta">
+          <span className="category-badge">{item.category}</span>
+        </div>
         <div className="quantity-section">
           <div className="quantity-display">
             <span className="quantity-number">{item.quantity}</span>
@@ -219,7 +221,7 @@ const InventoryItem = ({ item, onUpdate, onDelete, categories, statuses }) => {
           <div className="notes-section">
             <div className="notes-icon">📝</div>
             <span className="notes-label">Notes</span>
-            <span className="notes-text">Add notes</span>
+            <span className="notes-text">{item.notes}</span>
           </div>
         )}
 


### PR DESCRIPTION

This pull request updates the inventory item component layout and styling to improve visual organization and usability. The main changes involve moving the category badge to a new metadata section, adjusting spacing and flex properties for better wrapping and alignment, and ensuring notes display the actual item content.

**Layout and Styling Improvements:**

* Added `.item-meta` section to display the category badge below the item title, with new CSS for spacing and alignment. [[1]](diffhunk://#diff-60f5dcfc15327d5dd812d9df394c217efbedb4aa33dca782ed69d39dce811972R607-R614) [[2]](diffhunk://#diff-aa55c689bada0089cd50d79702b802025143e83825ecfacd582aa45e945b3508R194-R196)
* Updated flex properties and added `gap` and `flex-wrap` to the main container and item title section for improved responsiveness and wrapping.
* Adjusted padding in `.item-body` for more consistent spacing.

**Component Functionality Updates:**

* Moved the category badge from the title section to the new metadata section for clearer separation. [[1]](diffhunk://#diff-aa55c689bada0089cd50d79702b802025143e83825ecfacd582aa45e945b3508L174) [[2]](diffhunk://#diff-aa55c689bada0089cd50d79702b802025143e83825ecfacd582aa45e945b3508R194-R196)
* Updated notes display to show the actual item notes instead of a placeholder text.